### PR TITLE
Add simple double buffering to prevent thread blocking

### DIFF
--- a/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -797,7 +797,10 @@ namespace UnityWebBrowser.Core
             if(pixelDataLock != null)
                 lock (pixelDataLock)
                     pixelData.Dispose();
-
+                    
+            if(nextTextureData != null){
+                nextTextureData.Dispose();
+            }
             if (ReadySignalReceived && IsConnected)
                 communicationsManager.Shutdown();
 

--- a/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -798,9 +798,6 @@ namespace UnityWebBrowser.Core
                 lock (pixelDataLock)
                     pixelData.Dispose();
                     
-            if(nextTextureData != null){
-                nextTextureData.Dispose();
-            }
             if (ReadySignalReceived && IsConnected)
                 communicationsManager.Shutdown();
 
@@ -822,6 +819,10 @@ namespace UnityWebBrowser.Core
 
                 engineProcess.Dispose();
                 engineProcess = null;
+            }
+
+            if(nextTextureData != null){
+                nextTextureData.Dispose();
             }
         }
 

--- a/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
+++ b/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
@@ -54,7 +54,7 @@ namespace UnityWebBrowser.Core
 
             ReadWriterUtils.AddBaseTypeReadWriters(ipcClient.TypeReaderWriterManager);
 
-            pixelsEventTypeReader = new PixelsEventTypeReader(browserClient.textureData);
+            pixelsEventTypeReader = new PixelsEventTypeReader(browserClient.nextTextureData);
             ipcClient.TypeReaderWriterManager.AddType(pixelsEventTypeReader);
             
             ipcClient.AddService<IEngine>();


### PR DESCRIPTION
Unsafe texture data is now loaded into `NativeArray<byte> nextTextureData`  in WebBrowserCommunicationsManager.cs before being copied into `textureData` in WebBrowserClient.cs. This allows full images to be passed from thread to thread without tearing or large amounts of stalling due to locking between threads. 

This set of changes also removes locking altogether from texture.Apply. 