### PR TITLE
CefEventFlags support

### DIFF
--- a/src/UnityWebBrowser.Engine.Cef/Shared/Browser/UwbCefClient.cs
+++ b/src/UnityWebBrowser.Engine.Cef/Shared/Browser/UwbCefClient.cs
@@ -137,27 +137,42 @@ internal class UwbCefClient : CefClient, IDisposable
 
     #region Engine Events
 
+    private CefEventFlags GetKeyDirection(WindowsKey key) => key switch
+    {
+        WindowsKey.LShiftKey | WindowsKey.LControlKey | WindowsKey.LMenu => CefEventFlags.IsLeft,
+        WindowsKey.RShiftKey | WindowsKey.RControlKey | WindowsKey.RMenu => CefEventFlags.ShiftDown,
+        _ => CefEventFlags.None
+    };
+
     /// <summary>
     ///     Process a <see cref="KeyboardEvent" />
     /// </summary>
     /// <param name="keyboardEvent"></param>
     public void ProcessKeyboardEvent(KeyboardEvent keyboardEvent)
     {
+        UpdateModifiers(keyboardEvent);
+
         //Keys down
-        foreach (WindowsKey i in keyboardEvent.KeysDown)
+        foreach (WindowsKey key in keyboardEvent.KeysDown)
+        {
             KeyEvent(new CefKeyEvent
             {
-                WindowsKeyCode = (int)i,
-                EventType = CefKeyEventType.KeyDown
+                WindowsKeyCode = (int)key,
+                EventType = CefKeyEventType.KeyDown,
+                Modifiers = Modifiers | GetKeyDirection(key)
             });
+        }
 
         //Keys up
-        foreach (WindowsKey i in keyboardEvent.KeysUp)
+        foreach (WindowsKey key in keyboardEvent.KeysUp)
+        {
             KeyEvent(new CefKeyEvent
             {
-                WindowsKeyCode = (int)i,
-                EventType = CefKeyEventType.KeyUp
+                WindowsKeyCode = (int)key,
+                EventType = CefKeyEventType.KeyUp,
+                Modifiers = Modifiers | GetKeyDirection(key)
             });
+        }
 
         //Chars
         foreach (char c in keyboardEvent.Chars)
@@ -168,20 +183,102 @@ internal class UwbCefClient : CefClient, IDisposable
 #else
                 Character = c,
 #endif
-                EventType = CefKeyEventType.Char
+                EventType = CefKeyEventType.Char,
+                Modifiers = Modifiers
             });
+    }
+
+    /// <summary>
+    /// State of mouse click events that needs to be persisted for dragging
+    /// </summary>
+    private CefEventFlags Modifiers = CefEventFlags.None;
+
+    private void UpdateModifiers(MouseClickEvent mouseClickEvent)
+    {
+        var flag = mouseClickEvent.MouseClickType switch
+        {
+            MouseClickType.Left => CefEventFlags.LeftMouseButton,
+            MouseClickType.Right => CefEventFlags.RightMouseButton,
+            MouseClickType.Middle => CefEventFlags.MiddleMouseButton,
+            _ => throw new ArgumentException("Click event must be one of 3 states")
+        };
+
+        if (mouseClickEvent.MouseEventType == MouseEventType.Up)
+        {
+            Modifiers &= ~flag;
+        }
+        else
+        {
+            Modifiers |= flag;
+        }
+    }
+
+    private CefEventFlags KeyToFlag(WindowsKey key) => key switch
+    {
+        // Stateful keys
+        WindowsKey.CapsLock => CefEventFlags.CapsLockOn,
+        WindowsKey.NumLock => CefEventFlags.NumLockOn,
+
+        WindowsKey.Shift => CefEventFlags.ShiftDown,
+        WindowsKey.ShiftKey => CefEventFlags.ShiftDown,
+        WindowsKey.LShiftKey => CefEventFlags.ShiftDown,
+        WindowsKey.RShiftKey => CefEventFlags.ShiftDown,
+
+        WindowsKey.Control => CefEventFlags.ControlDown,
+        WindowsKey.ControlKey => CefEventFlags.ControlDown,
+        WindowsKey.LControlKey => CefEventFlags.ControlDown,
+        WindowsKey.RControlKey => CefEventFlags.ControlDown,
+
+        WindowsKey.Alt => CefEventFlags.AltGrDown,
+        WindowsKey.Menu => CefEventFlags.AltDown,
+        WindowsKey.LMenu => CefEventFlags.AltDown,
+        WindowsKey.RMenu => CefEventFlags.AltDown,
+        // No support for command
+
+        _ => CefEventFlags.None
+    };
+
+    private void UpdateModifiers(KeyboardEvent keyboardEvent)
+    {
+        foreach (var key in keyboardEvent.KeysDown)
+        {
+            var flag = KeyToFlag(key);
+
+            if ((key is WindowsKey.CapsLock && ((Modifiers & CefEventFlags.CapsLockOn) != CefEventFlags.None))
+                || (key is WindowsKey.NumLock && ((Modifiers & CefEventFlags.NumLockOn) != CefEventFlags.None)))
+            {
+                Modifiers &= ~flag;
+            }
+            else
+            {
+                Modifiers |= flag;
+            }
+        }
+
+        foreach (var key in keyboardEvent.KeysUp)
+        {
+            var flag = KeyToFlag(key);
+
+            if (key is WindowsKey.CapsLock || key is WindowsKey.NumLock)
+            {
+                return;
+            }
+
+            Modifiers &= ~flag;
+        }
     }
 
     /// <summary>
     ///     Process a <see cref="VoltstroStudios.UnityWebBrowser.Shared.Events.MouseMoveEvent" />
     /// </summary>
-    /// <param name="mouseEvent"></param>
-    public void ProcessMouseMoveEvent(MouseMoveEvent mouseEvent)
+    /// <param name="mouseMoveEvent"></param>
+    public void ProcessMouseMoveEvent(MouseMoveEvent mouseMoveEvent)
     {
         MouseMoveEvent(new CefMouseEvent
         {
-            X = mouseEvent.MouseX,
-            Y = mouseEvent.MouseY
+            X = mouseMoveEvent.MouseX,
+            Y = mouseMoveEvent.MouseY,
+            Modifiers = Modifiers
         });
     }
 
@@ -191,11 +288,14 @@ internal class UwbCefClient : CefClient, IDisposable
     /// <param name="mouseClickEvent"></param>
     public void ProcessMouseClickEvent(MouseClickEvent mouseClickEvent)
     {
+        UpdateModifiers(mouseClickEvent);
+
         MouseClickEvent(new CefMouseEvent
-            {
-                X = mouseClickEvent.MouseX,
-                Y = mouseClickEvent.MouseY
-            }, mouseClickEvent.MouseClickCount,
+        {
+            X = mouseClickEvent.MouseX,
+            Y = mouseClickEvent.MouseY,
+            Modifiers = Modifiers
+        }, mouseClickEvent.MouseClickCount,
             (CefMouseButtonType)mouseClickEvent.MouseClickType,
             mouseClickEvent.MouseEventType == MouseEventType.Up);
     }
@@ -209,7 +309,8 @@ internal class UwbCefClient : CefClient, IDisposable
         MouseScrollEvent(new CefMouseEvent
         {
             X = mouseScrollEvent.MouseX,
-            Y = mouseScrollEvent.MouseY
+            Y = mouseScrollEvent.MouseY,
+            Modifiers = Modifiers
         }, mouseScrollEvent.MouseScroll);
     }
 


### PR DESCRIPTION
I have noticed that some actions are not present when I work with UWB like dragging the scroll handle instead of using the mouse scroll. Apparently it's due to `Cef` expecting the input state information to be passed with each event and now `CefClient` maintains this state and such actions are possible.

_P.S. I have not found any docs on how I should manage `CefEventFlags.IsKeyPad` and `CefEventFlags.IsRepeat` flags and I doubt there is a way to use `CefEventFlags.CommandDown` flag with `WindowsKey` type :(_