### PR TITLE
feat: add no sandbox flag

### DIFF
--- a/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -167,6 +167,12 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         public bool ignoreSslErrors = false;
 
         /// <summary>
+        ///     Disables sandbox
+        /// </summary>
+        [Tooltip("Disables sandbox")]
+        public bool noSandbox = false;
+
+        /// <summary>
         ///     Domains to ignore SSL errors on if <see cref="ignoreSslErrors"/> is enabled
         /// </summary>
         [Tooltip("Domains to ignore SSL errors on if ignoreSSLErrors is enabled")]
@@ -410,6 +416,12 @@ namespace VoltstroStudios.UnityWebBrowser.Core
 #if UWB_ENGINE_PRJ //Define for backup, cause I am dumb as fuck and gonna accidentally include this in a release build one day 
             //argsBuilder.AppendArgument("start-delay", 2000);
 #endif
+
+            //Disable sandbox
+            if (noSandbox)
+            {
+                argsBuilder.AppendArgument("no-sandbox", true);
+            }
 
             //Final built arguments
             string arguments = argsBuilder.ToString();


### PR DESCRIPTION
This PR addresses an issue where the UnityWebBrowser fails to function on Windows virtual machines running inside Parallels on Macs with Apple silicon when sandboxing is enabled. To resolve this, the ability to toggle sandboxing has been added, allowing users to disable it for compatibility with these environments.