### PR TITLE
feat: Add configurable WindowlessFrameRate setting

### DIFF
--- a/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -131,6 +131,15 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         [Tooltip("Proxy settings")] public ProxySettings proxySettings;
         
         /// <summary>
+        ///     Target framerate for the browser rendering (1-60 FPS).
+        ///     Higher values provide smoother video playback but use more CPU.
+        /// </summary>
+        [Header("Performance")]
+        [Tooltip("Target framerate for browser rendering (1-60). Higher = smoother but more CPU.")]
+        [Range(1, 60)]
+        public int windowlessFrameRate = 30;
+
+        /// <summary>
         ///     Enable or disable WebRTC
         /// </summary>
         [Header("Advanced")]
@@ -376,6 +385,9 @@ namespace VoltstroStudios.UnityWebBrowser.Core
             //Width & Height
             argsBuilder.AppendArgument("width", resolution.Width);
             argsBuilder.AppendArgument("height", resolution.Height);
+
+            //Windowless frame rate
+            argsBuilder.AppendArgument("windowless-frame-rate", windowlessFrameRate);
 
             //Javascript
             argsBuilder.AppendArgument("javascript", javascript);

--- a/src/UnityWebBrowser.Engine.Cef/Main/Core/CefEngineControlsManager.cs
+++ b/src/UnityWebBrowser.Engine.Cef/Main/Core/CefEngineControlsManager.cs
@@ -198,11 +198,16 @@ internal class CefEngineControlsManager : IEngineControls, IDisposable
         //Create our CEF browser settings
         Color suppliedColor = launchArguments.BackgroundColor;
         CefColor backgroundColor = new(suppliedColor.A, suppliedColor.R, suppliedColor.G, suppliedColor.B);
+
+        //Clamp framerate to valid CEF range (1-60)
+        int frameRate = Math.Clamp(launchArguments.WindowlessFrameRate, 1, 60);
+
         CefBrowserSettings cefBrowserSettings = new()
         {
             BackgroundColor = backgroundColor,
             JavaScript = launchArguments.JavaScript ? CefState.Enabled : CefState.Disabled,
-            LocalStorage = launchArguments.LocalStorage ? CefState.Enabled : CefState.Disabled
+            LocalStorage = launchArguments.LocalStorage ? CefState.Enabled : CefState.Disabled,
+            WindowlessFrameRate = frameRate
         };
 
         mainLogger.LogDebug($"Starting CEF with these options:" +
@@ -212,6 +217,7 @@ internal class CefEngineControlsManager : IEngineControls, IDisposable
                      $"\nBackgroundColor: {suppliedColor}" +
                      $"\nCache Path: {cachePath}" +
                      $"\nPopup Action: {launchArguments.PopupAction}" +
+                     $"\nWindowless Frame Rate: {frameRate}" +
                      $"\nLog Path: {launchArguments.LogPath.FullName}" +
                      $"\nLog Severity: {launchArguments.LogSeverity}");
         mainLogger.LogInformation($"Starting CEF client...");

--- a/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArguments.cs
+++ b/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArguments.cs
@@ -134,4 +134,10 @@ public class LaunchArguments
     ///     Start delay. Used for testing reasons.
     /// </summary>
     internal uint StartDelay { get; set; }
+
+    /// <summary>
+    ///     The target framerate for windowless rendering (1-60 FPS).
+    ///     Default is 30 FPS.
+    /// </summary>
+    public int WindowlessFrameRate { get; init; }
 }

--- a/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArgumentsBinder.cs
+++ b/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArgumentsBinder.cs
@@ -24,6 +24,7 @@ internal class LaunchArgumentsBinder : BinderBase<LaunchArguments>
     private readonly Option<int> height;
 
     //General browser settings
+    private readonly Option<int> windowlessFrameRate;
     private readonly Option<bool> javaScript;
     private readonly Option<bool> webRtc;
     private readonly Option<bool> localStorage;
@@ -62,8 +63,9 @@ internal class LaunchArgumentsBinder : BinderBase<LaunchArguments>
         Option<string> initialUrl,
         Option<int> width,
         Option<int> height,
+        Option<int> windowlessFrameRate,
         Option<bool> javaScript,
-        Option<bool> webRtc, 
+        Option<bool> webRtc,
         Option<bool> localStorage,
         Option<int> remoteDebugging,
         Option<string[]> remoteDebuggingAllowedOrigins,
@@ -87,7 +89,8 @@ internal class LaunchArgumentsBinder : BinderBase<LaunchArguments>
         this.initialUrl = initialUrl;
         this.width = width;
         this.height = height;
-        
+
+        this.windowlessFrameRate = windowlessFrameRate;
         this.javaScript = javaScript;
         this.webRtc = webRtc;
         this.localStorage = localStorage;
@@ -126,6 +129,7 @@ internal class LaunchArgumentsBinder : BinderBase<LaunchArguments>
             Width = bindingContext.ParseResult.GetValueForOption(width),
             Height = bindingContext.ParseResult.GetValueForOption(height),
 
+            WindowlessFrameRate = bindingContext.ParseResult.GetValueForOption(windowlessFrameRate),
             JavaScript = bindingContext.ParseResult.GetValueForOption(javaScript),
             WebRtc = bindingContext.ParseResult.GetValueForOption(webRtc),
             LocalStorage = bindingContext.ParseResult.GetValueForOption(localStorage),

--- a/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArgumentsParser.cs
+++ b/src/VoltstroStudios.UnityWebBrowser.Engine.Shared/Core/LaunchArgumentsParser.cs
@@ -35,6 +35,9 @@ public sealed class LaunchArgumentsParser
             "The height of the window");
 
         //General browser settings
+        Option<int> windowlessFrameRate = new("-windowless-frame-rate",
+            () => 30,
+            "Target framerate for windowless rendering (1-60). Default is 30.");
         Option<bool> javaScript = new("-javascript",
             () => true,
             "Enable or disable javascript");
@@ -117,6 +120,7 @@ public sealed class LaunchArgumentsParser
             initialUrl,
             width,
             height,
+            windowlessFrameRate,
             javaScript,
             webRtc,
             localStorage,
@@ -147,6 +151,7 @@ public sealed class LaunchArgumentsParser
             initialUrl,
             width,
             height,
+            windowlessFrameRate,
             javaScript,
             webRtc,
             localStorage,


### PR DESCRIPTION
## Summary

Adds a configurable `WindowlessFrameRate` setting that allows users to control CEF's rendering framerate from 1-60 FPS (default 30). This enables smoother video playback when needed, while keeping the conservative default for CPU efficiency.

### Changes

- **LaunchArguments.cs**: Added `WindowlessFrameRate` property
- **LaunchArgumentsParser.cs**: Added `-windowless-frame-rate` command line option (default: 30)
- **LaunchArgumentsBinder.cs**: Added binding for the new option
- **CefEngineControlsManager.cs**: Applied framerate setting to `CefBrowserSettings.WindowlessFrameRate` with clamping to valid range (1-60)
- **WebBrowserClient.cs**: Added Unity Inspector field with `[Range(1, 60)]` slider under new "Performance" header

### Usage

In Unity Inspector, the `WebBrowserClient` component now shows a "Performance" section with a "Windowless Frame Rate" slider. Users can set values from 1-60 FPS depending on their needs:
- **30 FPS** (default): Good balance for most web content
- **60 FPS**: Smoother video playback, higher CPU usage

## Test Plan

- [x] Built CEF engine for macOS arm64
- [x] Verified engine accepts `-windowless-frame-rate` argument via `--help`
- [x] Tested in Unity project - Inspector shows new Performance section with framerate slider
- [x] Confirmed argument is passed from Unity to engine process